### PR TITLE
Subsampling tooltip

### DIFF
--- a/src/python/sortingview/gui/extensions/correlograms/AutoCorrelograms.tsx
+++ b/src/python/sortingview/gui/extensions/correlograms/AutoCorrelograms.tsx
@@ -1,9 +1,12 @@
-import React, { useMemo } from 'react';
+import { IconButton } from '@material-ui/core';
+import { Help } from '@material-ui/icons';
+import { useVisible } from 'labbox-react';
+import MarkdownDialog from 'labbox-react/components/Markdown/MarkdownDialog';
+import React, { Fragment, useMemo } from 'react';
 import SortingUnitPlotGrid from '../../commonComponents/SortingUnitPlotGrid/SortingUnitPlotGrid';
 import { SortingViewProps } from "../../pluginInterface";
+import correlogramSubsamplingInfo from './CorrelogramSubsamplingInfo.md.gen';
 import CorrelogramRv2 from './Correlogram_ReactVis2';
-
-// const autocorrelogramsCalculationPool = createCalculationPool({maxSimultaneous: 6});
 
 const AutoCorrelograms: React.FunctionComponent<SortingViewProps> = ({ sorting, selection, curation, selectionDispatch }) => {
     const unitComponent = useMemo(() => (unitId: number) => (
@@ -14,33 +17,27 @@ const AutoCorrelograms: React.FunctionComponent<SortingViewProps> = ({ sorting, 
         />
     ), [sorting, selection, selectionDispatch, curation])
 
+    const subsamplingPopupVisible = useVisible()
+
     return (
-        <SortingUnitPlotGrid
-            sorting={sorting}
-            selection={selection}
-            curation={curation}
-            selectionDispatch={selectionDispatch}
-            unitComponent={unitComponent}
-        />
+        <Fragment>
+            <div>
+                <IconButton onClick={subsamplingPopupVisible.show}><Help /></IconButton>
+            </div>
+            <SortingUnitPlotGrid
+                sorting={sorting}
+                selection={selection}
+                curation={curation}
+                selectionDispatch={selectionDispatch}
+                unitComponent={unitComponent}
+            />
+            <MarkdownDialog
+                visible={subsamplingPopupVisible.visible}
+                onClose={subsamplingPopupVisible.hide}
+                source={correlogramSubsamplingInfo}
+            />
+        </Fragment>
     )
-    // return (
-    //     <PlotGrid
-    //         sorting={sorting}
-    //         selections={selectedUnitIdsLookup}
-    //         onUnitClicked={handleUnitClicked}
-    //         dataFunctionName={'createjob_fetch_correlogram_plot_data'}
-    //         dataFunctionArgsCallback={(unitId: number) => ({
-    //             sorting_object: sorting.sortingObject,
-    //             unit_x: unitId
-    //         })}
-    //         // use default boxSize
-    //         plotComponent={Correlogram_rv}
-    //         plotComponentArgsCallback={(unitId: number) => ({
-    //             id: 'plot-'+unitId
-    //         })}
-    //         calculationPool={autocorrelogramsCalculationPool}
-    //     />
-    // );
 }
 
 export default AutoCorrelograms

--- a/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md
+++ b/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md
@@ -1,10 +1,17 @@
 # Subsampling
 
 For efficiency, sortings are subsampled when creating auto- and cross-correlograms.
-Sampling using tight time windows poses the risk that one of a pair of firing events
-will fall outside the window, and fail to be detected--particularly for units with
-lower firing rates. However, using long contiguous windows risks inducing bias
-toward particular areas of the recording.
+Since cross-correlograms make comparisons between different units, the spike trains
+are sampled according to windows of time, rather than sampling firing events--pure
+random subsampling of events is not optimal because it is less likely that both
+spikes in an event pair which could appear in the histogram will be part of the
+random sample.
+
+Even with time-based sampling, there is a risk of missing pairs of events that
+ought to appear in the histogram. In particular, if the sample windows are
+brief, there is a risk that the window will capture only one-half of a pair of
+firing events. However, more protracted time samples increase the risk of
+inducing bias toward certain areas of the recording.
 
 The default sampling strategy strikes a balance between these risks by sampling
 all units in 100 slices of 10 seconds each, resulting in 1000 seconds of observations

--- a/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md
+++ b/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md
@@ -1,5 +1,13 @@
 # Subsampling
 
-For efficiency, sortings are subsampled when creating auto- and cross-correlograms. By default,
-the system will subsample all units to 100 slices of 10 seconds each, evenly distributed across
-the recording.
+For efficiency, sortings are subsampled when creating auto- and cross-correlograms.
+Sampling using tight time windows poses the risk that one of a pair of firing events
+will fall outside the window, and fail to be detected--particularly for units with
+lower firing rates. However, using long contiguous windows risks inducing bias
+toward particular areas of the recording.
+
+The default sampling strategy strikes a balance between these risks by sampling
+all units in 100 slices of 10 seconds each, resulting in 1000 seconds of observations
+evenly distributed across the duration of the recording. Sampling is only used if
+less than half of the recording would be included in the samples; shorter recordings
+are used in their entirety.

--- a/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md
+++ b/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md
@@ -1,0 +1,5 @@
+# Subsampling
+
+For efficiency, sortings are subsampled when creating auto- and cross-correlograms. By default,
+the system will subsample all units to 100 slices of 10 seconds each, evenly distributed across
+the recording.

--- a/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md.gen.ts
+++ b/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md.gen.ts
@@ -1,3 +1,12 @@
-const text: string = "# Text describing the correlogram subsampling\n\nThis is supposed to be auto-generated\n\nIt should be appearing"
+const text: string = "# Subsampling\n\nFor efficiency, sortings are subsampled when creating auto- and cross-correlograms.\n " +
+"Sampling using tight time windows poses the risk that one of a pair of firing events\n" +
+"will fall outside the window, and fail to be detected--particularly for units with\n" +
+"lower firing rates. However, using long contiguous windows risks inducing bias\n" +
+"toward particular areas of the recording.\n\n" +
+"The default sampling strategy strikes a balance between these risks by sampling\n" +
+"all units in 100 slices of 10 seconds each, resulting in 1000 seconds of observations\n" +
+"evenly distributed across the duration of the recording. Sampling is only used if\n" +
+"less than half of the recording would be included in the samples; shorter recordings\n" +
+"are used in their entirety."
 
 export default text

--- a/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md.gen.ts
+++ b/src/python/sortingview/gui/extensions/correlograms/CorrelogramSubsamplingInfo.md.gen.ts
@@ -1,0 +1,3 @@
+const text: string = "# Text describing the correlogram subsampling\n\nThis is supposed to be auto-generated\n\nIt should be appearing"
+
+export default text

--- a/src/python/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsView.tsx
+++ b/src/python/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsView.tsx
@@ -1,29 +1,12 @@
-import React, { FunctionComponent, useMemo, useState } from 'react'
-import { SortingSelection, SortingSelectionAction, SortingSelectionDispatch, SortingViewProps } from "../../../pluginInterface"
-import SelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/SelectUnitsWidget'
-import CrossCorrelogramsWidget from './CrossCorrelogramsWidget'
+
 import Splitter from 'labbox-react/components/Splitter/Splitter';
-
-const useLocalUnitIds = (selection: SortingSelection, selectionDispatch: SortingSelectionDispatch): [SortingSelection, SortingSelectionDispatch] => {
-    const [selectedUnitIds, setSelectedUnitIds] = useState<number[]>([])
-    const selectionLocal: SortingSelection = useMemo(() => ({
-        ...selection,
-        selectedUnitIds
-    }), [selectedUnitIds, selection])
-
-    const selectionDispatchLocal = useMemo(() => ((action: SortingSelectionAction) => {
-        if (action.type === 'SetSelectedUnitIds') {
-            setSelectedUnitIds(action.selectedUnitIds)
-        }
-        else {
-            selectionDispatch(action)
-        }
-    }), [selectionDispatch])
-    return [selectionLocal, selectionDispatchLocal]
-}
+import React, { FunctionComponent } from 'react';
+import SelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/SelectUnitsWidget';
+import { SortingViewProps } from "../../../pluginInterface";
+import useLocalUnitIds from '../../../pluginInterface/useLocalUnitIds';
+import CrossCorrelogramsWidget from './CrossCorrelogramsWidget';
 
 const CrossCorrelogramsView: FunctionComponent<SortingViewProps> = ({sorting, selection, curation, selectionDispatch, width, height}) => {
-
     // Make a local selection/selectionDispatch pair that overrides the selectedUnitIds
     const [selectionLocal, selectionDispatchLocal] = useLocalUnitIds(selection, selectionDispatch)
 

--- a/src/python/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsWidget.tsx
+++ b/src/python/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsWidget.tsx
@@ -1,6 +1,11 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import { IconButton } from '@material-ui/core';
+import { Help } from '@material-ui/icons';
+import { useVisible } from 'labbox-react';
+import MarkdownDialog from 'labbox-react/components/Markdown/MarkdownDialog';
+import React, { Fragment, FunctionComponent, useMemo } from 'react';
 import SortingUnitPairPlotGrid from '../../../commonComponents/SortingUnitPairPlotGrid/SortingUnitPairPlotGrid';
 import { Sorting, SortingCuration, SortingSelection, SortingSelectionDispatch } from "../../../pluginInterface";
+import correlogramSubsamplingInfo from '../CorrelogramSubsamplingInfo.md.gen';
 import CorrelogramRv2 from '../Correlogram_ReactVis2';
 
 type Props = {
@@ -30,15 +35,27 @@ const CrossCorrelogramsWidget: FunctionComponent<Props> = ({ sorting, selection,
             height={plotHeight}
         />
     ), [sorting, selection, selectionDispatch, plotWidth, plotHeight, curation])
+    const subsamplingPopupVisible = useVisible()
+
 
     return (
-        <SortingUnitPairPlotGrid
-            sorting={sorting}
-            selection={selection}
-            selectionDispatch={selectionDispatch}
-            unitIds={unitIds}
-            unitPairComponent={unitPairComponent}
-        />
+        <Fragment>
+            <div>
+                <IconButton onClick={subsamplingPopupVisible.show}><Help /></IconButton>
+            </div>
+            <SortingUnitPairPlotGrid
+                sorting={sorting}
+                selection={selection}
+                selectionDispatch={selectionDispatch}
+                unitIds={unitIds}
+                unitPairComponent={unitPairComponent}
+            />
+            <MarkdownDialog
+                visible={subsamplingPopupVisible.visible}
+                onClose={subsamplingPopupVisible.hide}
+                source={correlogramSubsamplingInfo}
+            />
+        </Fragment>
     )
 }
 


### PR DESCRIPTION
Fixes issue #37.

This PR adds a standard help icon to the top of the layout of the cross- and auto-correlograms. When it is clicked, a modal popup is displayed which describes subsampling strategy.

Text for popup should be generated from `CorrelogramSubsamplingInfo.md` in the `src/python/sortingview/gui/extensions/correlograms/` directory (along with the rest of the correlograms components).

Also changed, the Cross-Correlograms view had been using a cut-and-pasted version of the `useLocalUnitIds` hook; I replaced this with a reference to the library version.