### PR TITLE
Adds lockable unit selection & toggleable useLocalUnitIds.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,13 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.lock-switch {
+  padding-left: 15px;
+}
+
+.lock-switch-label {
+  font-size: 12;
+  color: cornflowerblue;
+  /* color:crimson; */
+}

--- a/src/index.css
+++ b/src/index.css
@@ -15,9 +15,3 @@ code {
 .lock-switch {
   padding-left: 15px;
 }
-
-.lock-switch-label {
-  font-size: 12;
-  color: cornflowerblue;
-  /* color:crimson; */
-}

--- a/src/python/sortingview/gui/commonComponents/SelectUnitsWidget/LockableSelectUnitsWidget.tsx
+++ b/src/python/sortingview/gui/commonComponents/SelectUnitsWidget/LockableSelectUnitsWidget.tsx
@@ -1,0 +1,30 @@
+import { FormControlLabel, FormGroup, Typography } from '@material-ui/core';
+import Switch from '@material-ui/core/Switch';
+import React, { Fragment, FunctionComponent } from 'react';
+import { Sorting, SortingCuration, SortingSelection, SortingSelectionDispatch } from "../../pluginInterface";
+import SelectUnitsWidget from './SelectUnitsWidget';
+
+type Props = {
+    sorting: Sorting
+    selection: SortingSelection
+    selectionDispatch: SortingSelectionDispatch
+    curation: SortingCuration
+    locked: boolean
+    toggleLockStateCallback: () => void
+}
+
+const LockableSelectUnitsWidget: FunctionComponent<Props> = ({ sorting, selection, selectionDispatch, curation, locked, toggleLockStateCallback }) => {
+    return (
+        <Fragment>
+            <FormGroup className={"lock-switch"}>
+                <FormControlLabel
+                    control={ <Switch checked={locked} size={"small"} onChange={() => toggleLockStateCallback()} /> }
+                    label={<Typography variant="caption">Lock selection</Typography>}
+                />
+            </FormGroup>
+            <SelectUnitsWidget sorting={sorting} selection={selection} selectionDispatch={selectionDispatch} curation={curation} selectionDisabled={locked} />
+        </Fragment>
+    )
+}
+
+export default LockableSelectUnitsWidget

--- a/src/python/sortingview/gui/commonComponents/SelectUnitsWidget/SelectUnitsWidget.tsx
+++ b/src/python/sortingview/gui/commonComponents/SelectUnitsWidget/SelectUnitsWidget.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { isMergeGroupRepresentative, Sorting, SortingCuration, SortingSelection, SortingSelectionDispatch } from "../../pluginInterface";
 import UnitsTable from '../../extensions/unitstable/Units/UnitsTable';
+import { isMergeGroupRepresentative, Sorting, SortingCuration, SortingSelection, SortingSelectionDispatch } from "../../pluginInterface";
 import { useSortingInfo } from '../../pluginInterface/useSortingInfo';
 
 type Props = {
@@ -8,9 +8,10 @@ type Props = {
     selection: SortingSelection
     selectionDispatch: SortingSelectionDispatch
     curation: SortingCuration
+    selectionDisabled?: boolean
 }
 
-const SelectUnitsWidget: FunctionComponent<Props> = ({ sorting, selection, selectionDispatch, curation }) => {
+const SelectUnitsWidget: FunctionComponent<Props> = ({ sorting, selection, selectionDispatch, curation, selectionDisabled }) => {
     const sortingInfo = useSortingInfo(sorting.sortingPath)
     if (!sortingInfo) return <div>No sorting info</div>
     let unitIds = (selection.visibleUnitIds || (sortingInfo?.unit_ids || []))
@@ -18,7 +19,7 @@ const SelectUnitsWidget: FunctionComponent<Props> = ({ sorting, selection, selec
     return (
         <UnitsTable
             units={unitIds}
-            {...{selection, selectionDispatch, sorting, curation}}
+            {...{selection, selectionDispatch, sorting, curation, selectionDisabled}}
         />
     )
 }

--- a/src/python/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsView.tsx
+++ b/src/python/sortingview/gui/extensions/correlograms/CrossCorrelogramsView/CrossCorrelogramsView.tsx
@@ -1,31 +1,14 @@
-import React, { FunctionComponent, useMemo, useState } from 'react'
-import { SortingSelection, SortingSelectionAction, SortingSelectionDispatch, SortingViewProps } from "../../../pluginInterface"
-import SelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/SelectUnitsWidget'
-import CrossCorrelogramsWidget from './CrossCorrelogramsWidget'
 import Splitter from 'labbox-react/components/Splitter/Splitter';
-
-const useLocalUnitIds = (selection: SortingSelection, selectionDispatch: SortingSelectionDispatch): [SortingSelection, SortingSelectionDispatch] => {
-    const [selectedUnitIds, setSelectedUnitIds] = useState<number[]>([])
-    const selectionLocal: SortingSelection = useMemo(() => ({
-        ...selection,
-        selectedUnitIds
-    }), [selectedUnitIds, selection])
-
-    const selectionDispatchLocal = useMemo(() => ((action: SortingSelectionAction) => {
-        if (action.type === 'SetSelectedUnitIds') {
-            setSelectedUnitIds(action.selectedUnitIds)
-        }
-        else {
-            selectionDispatch(action)
-        }
-    }), [selectionDispatch])
-    return [selectionLocal, selectionDispatchLocal]
-}
+import useLocalUnitIds from 'python/sortingview/gui/pluginInterface/useLocalUnitIds';
+import React, { FunctionComponent, useState } from 'react';
+import LockableSelectUnitsWidget from '../../../commonComponents/SelectUnitsWidget/LockableSelectUnitsWidget';
+import { SortingViewProps } from "../../../pluginInterface";
+import CrossCorrelogramsWidget from './CrossCorrelogramsWidget';
 
 const CrossCorrelogramsView: FunctionComponent<SortingViewProps> = ({sorting, selection, curation, selectionDispatch, width, height}) => {
-
+    const [locked, setLocked] = useState(false)
     // Make a local selection/selectionDispatch pair that overrides the selectedUnitIds
-    const [selectionLocal, selectionDispatchLocal] = useLocalUnitIds(selection, selectionDispatch)
+    const [selectionLocal, selectionDispatchLocal] = useLocalUnitIds(selection, selectionDispatch, locked)
 
     return (
         <Splitter
@@ -33,7 +16,13 @@ const CrossCorrelogramsView: FunctionComponent<SortingViewProps> = ({sorting, se
             height={height || 900} // how to determine default height?
             initialPosition={200}
         >
-            <SelectUnitsWidget sorting={sorting} selection={selectionLocal} selectionDispatch={selectionDispatchLocal} curation={curation} />
+            <LockableSelectUnitsWidget
+                sorting={sorting}
+                selection={selectionLocal}
+                selectionDispatch={selectionDispatchLocal}
+                curation={curation}
+                locked={locked}
+                toggleLockStateCallback={() => setLocked(!locked)} />
             <CrossCorrelogramsWidget
                 sorting={sorting}
                 selection={selectionLocal}

--- a/src/python/sortingview/gui/extensions/unitstable/Units/TableWidget.tsx
+++ b/src/python/sortingview/gui/extensions/unitstable/Units/TableWidget.tsx
@@ -82,8 +82,8 @@ const HeaderRow: FunctionComponent<{
     )
 }
 
-const RowCheckbox = React.memo((props: {rowId: string, selected: boolean, onClick: (rowId: string) => void, isDeselectAll?: boolean}) => {
-    const { rowId, selected, onClick, isDeselectAll } = props
+const RowCheckbox = React.memo((props: {rowId: string, selected: boolean, onClick: (rowId: string) => void, isDeselectAll?: boolean, isDisabled?: boolean}) => {
+    const { rowId, selected, onClick, isDeselectAll, isDisabled } = props
     return (
         <Checkbox
             checked={selected}
@@ -93,6 +93,7 @@ const RowCheckbox = React.memo((props: {rowId: string, selected: boolean, onClic
                 padding: 1
             }}
             title={isDeselectAll ? "Deselect all" : `Select ${rowId}`}
+            disabled={isDisabled}
         />
     );
 });
@@ -104,6 +105,7 @@ interface Props {
     columns: Column[]
     defaultSortColumnName?: string
     height?: number
+    selectionDisabled?: boolean
 }
 
 type sortFieldEntry = {columnName: string, keyOrder: number, sortAscending: boolean}
@@ -119,7 +121,7 @@ const interpretSortFields = (fields: string[]): sortFieldEntry[] => {
 
 const TableWidget: FunctionComponent<Props> = (props) => {
 
-    const { selectedRowIds, onSelectedRowIdsChanged, rows, columns, defaultSortColumnName, height } = props
+    const { selectedRowIds, onSelectedRowIdsChanged, rows, columns, defaultSortColumnName, height, selectionDisabled } = props
 
     const [sortFieldOrder, setSortFieldOrder] = useState<string[]>([])
 
@@ -199,6 +201,7 @@ const TableWidget: FunctionComponent<Props> = (props) => {
                                             rowId={row.rowId}
                                             selected={selected}
                                             onClick = {() => toggleSelectedRowId(row.rowId)}
+                                            isDisabled={selectionDisabled}
                                         />
                                     </TableCell>
                                     {

--- a/src/python/sortingview/gui/extensions/unitstable/Units/UnitsTable.tsx
+++ b/src/python/sortingview/gui/extensions/unitstable/Units/UnitsTable.tsx
@@ -15,10 +15,11 @@ interface Props {
     sorting: Sorting
     curation: SortingCuration
     height?: number
+    selectionDisabled?: boolean
 }
 
 const UnitsTable: FunctionComponent<Props> = (props) => {
-    const { sorting, sortingUnitMetrics, units, metrics, selection, selectionDispatch, curation, height } = props
+    const { sorting, sortingUnitMetrics, units, metrics, selection, selectionDispatch, curation, height, selectionDisabled } = props
     const selectedUnitIds = ((selection || {}).selectedUnitIds || [])
     const sortingUnitMetricsList = sortByPriority(Object.values(sortingUnitMetrics || {})).filter(p => (!p.disabled))
 
@@ -173,6 +174,7 @@ const UnitsTable: FunctionComponent<Props> = (props) => {
             onSelectedRowIdsChanged={handleSelectedRowIdsChanged}
             defaultSortColumnName="_unit_id"
             height={height}
+            selectionDisabled={selectionDisabled}
         />
     )
 }

--- a/src/python/sortingview/gui/pluginInterface/useLocalUnitIds.ts
+++ b/src/python/sortingview/gui/pluginInterface/useLocalUnitIds.ts
@@ -1,21 +1,30 @@
 import { useMemo, useState } from 'react'
 import { SortingSelection, SortingSelectionAction, SortingSelectionDispatch } from "./"
 
-const useLocalUnitIds = (selection: SortingSelection, selectionDispatch: SortingSelectionDispatch): [SortingSelection, SortingSelectionDispatch] => {
-    const [selectedUnitIds, setSelectedUnitIds] = useState<number[]>([])
+const useLocalUnitIds = (selection: SortingSelection, selectionDispatch: SortingSelectionDispatch, usingLocal: boolean = false):
+                        [SortingSelection, SortingSelectionDispatch] => {
+    const globalSelectedIds = selection.selectedUnitIds ?? []
+    const [selectedUnitIds, setSelectedUnitIds] = useState<number[]>(globalSelectedIds)
+    if (!usingLocal &&
+            (selectedUnitIds.length !== globalSelectedIds.length ||
+             !selectedUnitIds.every((e) => globalSelectedIds.includes(e)))
+        ) {
+            setSelectedUnitIds(globalSelectedIds.sort())
+    }
+
     const selectionLocal: SortingSelection = useMemo(() => ({
         ...selection,
         selectedUnitIds
-    }), [selectedUnitIds, selection])
+    }), [selection, selectedUnitIds])
 
     const selectionDispatchLocal = useMemo(() => ((action: SortingSelectionAction) => {
-        if (action.type === 'SetSelectedUnitIds') {
-            setSelectedUnitIds(action.selectedUnitIds)
+        if (usingLocal && action.type === 'SetSelectedUnitIds') {
+            setSelectedUnitIds(action.selectedUnitIds.sort())
         }
         else {
             selectionDispatch(action)
         }
-    }), [selectionDispatch])
+    }), [usingLocal, selectionDispatch])
     return [selectionLocal, selectionDispatchLocal]
 }
 


### PR DESCRIPTION
Fixes #49.

There are a few changes worth noting here:

* `useLocalUnitIds` has been updated. It now takes an additional optional parameter named `usingLocal`. When this value is set to true, any selection updates will be applied only to the local set of selected unit IDs. When it is set to false, all actions (including updates to selected unit IDs) are passed to the global sorting selection reducer, and the local selection is updated to the global one whenever they differ.
* There is now a `LockableSelectUnitsWidget` that wraps a `SelectUnitsWidget` along with a slider switch to lock the component. Lock state is passed through to `SelectUnitsWidget` (and the child elements used to display the unit selection table) as a `selectionDisabled` parameter. When this parameter is set to true, the checkboxes for the unit selection table have the `disabled` flag set, so they are non-interactable in the UI.
* The slider was getting cut off in the UI as part of the component, so I added a style rule in `index.css` to pad it out a little bit.

Possible issues:
* While I tested this out for the cross-correlogram components, I haven't checked it out for unit comparisons.
* `useLocalUnitIds` syncs the local selections against the global selections with every render. Of course, it also has to check that the lists differ (or we'd get stuck in an endless render loop, where each attempt to render would reset the local list, causing a rerender, even though it was being reset to its current value!) While unlikely, it's possible this comparison could become expensive for very large sets of selections, since it's not implemented in any particularly intelligent fashion. (For instance, it might have been wiser to sort both lists and iterate over them together, or do some other algorithmically more efficient strategy.) Another alternative considered and rejected was for the `useLocalUnitIds` hook to return a callback which should be called by the parent component when unlocking; however this seemed needlessly complex for the current use case.
* Theoretically `useLocalUnitIds` now allows modification of the local selection set, but as I don't have anything set up in the UI to allow you to toggle on the 'using local' flag without also disabling the UI component you would use to change that set, I didn't test this.
* Users will need to be careful not to unlock a component list unless they mean to, as whatever selection they'll have will be lost (it'll revert to the global state) when they unlock. I do think this is the right approach, but it may bite people a few times before they learn.

We'll probably have a merge conflict between this PR and PR #51, regardless of merge order. Let me know when ready to merge and I'll take care of resolving it.