### PR TITLE
Implement a "Curation Completed/Reopen Curation" button.

### DIFF
--- a/src/python/sortingview/gui/extensions/mountainview/MVSortingView/CurationControl.tsx
+++ b/src/python/sortingview/gui/extensions/mountainview/MVSortingView/CurationControl.tsx
@@ -131,7 +131,13 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ selection, se
                             <Grid item key={labelChoice}>
                                 {
                                     (((labelCounts[labelChoice] || 0) < selectedUnitIds.length) || (!enableApply)) ? (
-                                        <button style={buttonStyle} disabled={!enableApply || (curation?.isClosed)} onClick={() => {_handleApplyLabel(labelChoice)}}>{labelChoice}</button>
+                                        <button
+                                            style={buttonStyle}
+                                            disabled={!enableApply || (curation?.isClosed)}
+                                            onClick={() => {_handleApplyLabel(labelChoice)}}
+                                        >
+                                            {labelChoice}
+                                        </button>
                                     ): <span />
                                 }
                             </Grid>

--- a/src/python/sortingview/gui/extensions/mountainview/MVSortingView/CurationControl.tsx
+++ b/src/python/sortingview/gui/extensions/mountainview/MVSortingView/CurationControl.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Grid, Paper } from '@material-ui/core';
+import { Button, Checkbox, Grid, Paper } from '@material-ui/core';
 import React, { FunctionComponent, useCallback, useMemo } from 'react';
 import sizeMe, { SizeMeProps } from 'react-sizeme';
 import { SortingCuration, SortingSelection, SortingSelectionDispatch } from '../../../pluginInterface';
@@ -54,6 +54,13 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ selection, se
             unitIds: selectedUnitIds
         })
     }, [curationDispatch, selectedUnitIds])
+
+    const handleToggleCurationClosed = useCallback((isClosed: boolean) => {
+        const type = isClosed ? 'REOPEN_CURATION' : 'CLOSE_CURATION'
+        curationDispatch({
+            type: type
+        })
+    }, [curationDispatch])
 
     const handleToggleApplyMerges = useCallback(() => {
         selectionDispatch({type: 'ToggleApplyMerges', curation})
@@ -138,6 +145,11 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ selection, se
                 <span style={{whiteSpace: 'nowrap'}}>
                     <Checkbox checked={selection.applyMerges || false} onClick={handleToggleApplyMerges}/> Apply merges
                 </span>
+            </Paper>
+            <Paper style={paperStyle} key="close">
+                <Button onClick={() => {handleToggleCurationClosed(curation?.isClosed || false )}}>
+                    { curation.isClosed ? 'Re-open curation' : 'Curation complete' }
+                </Button>
             </Paper>
         </div>
     )

--- a/src/python/sortingview/gui/extensions/mountainview/MVSortingView/CurationControl.tsx
+++ b/src/python/sortingview/gui/extensions/mountainview/MVSortingView/CurationControl.tsx
@@ -55,12 +55,12 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ selection, se
         })
     }, [curationDispatch, selectedUnitIds])
 
-    const handleToggleCurationClosed = useCallback((isClosed: boolean) => {
-        const type = isClosed ? 'REOPEN_CURATION' : 'CLOSE_CURATION'
+    const handleToggleCurationClosed = useCallback(() => {
+        const type = curation?.isClosed ? 'REOPEN_CURATION' : 'CLOSE_CURATION'
         curationDispatch({
             type: type
         })
-    }, [curationDispatch])
+    }, [curation.isClosed, curationDispatch])
 
     const handleToggleApplyMerges = useCallback(() => {
         selectionDispatch({type: 'ToggleApplyMerges', curation})
@@ -116,7 +116,7 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ selection, se
                                     label={r.label}
                                     partial={r.partial}
                                     onClick={() => {r.partial ? _handleApplyLabel(r.label) : _handleRemoveLabel(r.label)}}
-                                    disabled={curation?.isClosed || false}
+                                    disabled={curation?.isClosed}
                                 />
                             </Grid>
                         ))
@@ -143,13 +143,13 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ selection, se
                 Merge:
                 {
                     (selectedUnitIds.length >= 2 && !unitsAreInMergeGroups(selectedUnitIds)) &&
-                        <button key="merge" onClick={handleMergeSelected} disabled={curation?.isClosed || false}>
+                        <button key="merge" onClick={handleMergeSelected} disabled={curation?.isClosed}>
                             Merge selected units: {selectedUnitIds.join(', ')}
                         </button>
                 }
                 {
                     (selectedUnitIds.length > 0 && unitsAreInMergeGroups(selectedUnitIds)) &&
-                        <button key="unmerge" onClick={handleUnmergeSelected} disabled={curation?.isClosed || false}>
+                        <button key="unmerge" onClick={handleUnmergeSelected} disabled={curation?.isClosed}>
                             Unmerge units: {selectedUnitIds.join(', ')}
                         </button>
                 }
@@ -160,7 +160,7 @@ const CurationControl: FunctionComponent<Props & SizeMeProps> = ({ selection, se
             <Button
                 color={ curation?.isClosed ? "primary" : "secondary" }
                 variant={"contained"}
-                onClick={() => {handleToggleCurationClosed(curation?.isClosed || false )}}>
+                onClick={() => {handleToggleCurationClosed()}}>
                 { curation?.isClosed ? 'Re-open curation' : 'Curation complete' }
             </Button>
         </div>

--- a/src/python/sortingview/gui/pluginInterface/SortingCuration.ts
+++ b/src/python/sortingview/gui/pluginInterface/SortingCuration.ts
@@ -2,6 +2,7 @@ export type SortingCuration = {
     labelsByUnit?: {[key: string]: string[]}
     labelChoices?: string[]
     mergeGroups?: (number[])[]
+    isClosed?: boolean
 }
 
 export interface AddUnitLabelCurationAction {
@@ -31,7 +32,15 @@ export interface SetCurationCurationAction {
     curation: SortingCuration
 }
 
-export type SortingCurationAction = AddUnitLabelCurationAction | RemoveUnitLabelCurationAction | MergeUnitsCurationAction | UnmergeUnitsCurationAction | SetCurationCurationAction
+export interface CloseCurationCurationAction {
+    type: 'CLOSE_CURATION'
+}
+
+export interface ReopenCurationCurationAction {
+    type: 'REOPEN_CURATION'
+}
+
+export type SortingCurationAction = AddUnitLabelCurationAction | RemoveUnitLabelCurationAction | MergeUnitsCurationAction | UnmergeUnitsCurationAction | SetCurationCurationAction | CloseCurationCurationAction | ReopenCurationCurationAction
 
 export type SortingCurationDispatch = (action: SortingCurationAction) => void
 

--- a/src/python/sortingview/gui/pluginInterface/workspaceReducer.ts
+++ b/src/python/sortingview/gui/pluginInterface/workspaceReducer.ts
@@ -64,7 +64,10 @@ export type WorkspaceAction = AddRecordingWorkspaceAction | DeleteRecordingsWork
 
 export const sortingCurationReducer = (state: SortingCuration, action: SortingCurationAction): SortingCuration => {
     // disable state changes for a closed curation
-    if (action.type !== 'REOPEN_CURATION' && state.isClosed) return state
+    if (action.type !== 'REOPEN_CURATION' && state.isClosed) {
+        console.log(`WARNING: Attempt to curate a closed sorting curation:\n\tAction: ${action.type}`)
+        return state
+    }
 
     if (action.type === 'SET_CURATION') {
         return action.curation

--- a/src/python/sortingview/gui/pluginInterface/workspaceReducer.ts
+++ b/src/python/sortingview/gui/pluginInterface/workspaceReducer.ts
@@ -63,8 +63,17 @@ type SetsnippetLenWorkspaceAction = {
 export type WorkspaceAction = AddRecordingWorkspaceAction | DeleteRecordingsWorkspaceAction | AddSortingsWorkspaceAction | DeleteSortingsWorkspaceAction | DeleteSortingsForRecordingsWorkspaceAction | SetUnitMetricsForSortingWorkspaceAction | SetUserPermissionsAction | SetsnippetLenWorkspaceAction
 
 export const sortingCurationReducer = (state: SortingCuration, action: SortingCurationAction): SortingCuration => {
+    // disable state changes for a closed curation
+    if (action.type !== 'REOPEN_CURATION' && state.isClosed) return state
+
     if (action.type === 'SET_CURATION') {
         return action.curation
+    }
+    else if (action.type === 'CLOSE_CURATION') {
+        return { ...state, isClosed: true }
+    }
+    else if (action.type === 'REOPEN_CURATION') {
+        return { ...state, isClosed: false }
     }
     else if (action.type === 'ADD_UNIT_LABEL') {
         const uids: number[] = typeof(action.unitId) === 'object' ? action.unitId : [action.unitId]

--- a/src/python/sortingview/user_permissions.py
+++ b/src/python/sortingview/user_permissions.py
@@ -4,8 +4,7 @@ import kachery_client as kc
 key = '_sortingview_user_permissions'
 
 def set_user_permissions(user_id: str, *, append_to_all_feeds: Union[None, bool]=None):
-    p = kc.get(key)
-    if p is None: p = {}
+    p = kc.get(key, {})
     p_user = p.get(user_id, {})
     if append_to_all_feeds is not None:
         p_user['appendToAllFeeds'] = append_to_all_feeds


### PR DESCRIPTION
Fixes Issue #41.

This PR touches 5 files whose scope includes curation front-end through data persistence to feed.

On the front end:

* In `src/python/sortingview/gui/extensions/mountainview/MVSortingCiew/CurationControl.tsx`:
  * Implemented a button at the bottom of the "Curation" section which toggles 'Curation Complete' or 'Reopen Curation' depending on curation state
  * Curation button styling is appropriate to current sorting curation status
  * When curation is flagged complete, UI elements which take a curation action (label buttons, apply-label buttons, merge/unmerge button) are disabled. 
  * Unit selection in the main panel still works, as does the 'apply merges' button (which I'm not really clear what it does, but I don't think changes actual curation state?)
  * Fixed an incidental bug where the 'merge units' button would appear, even when all selected units were already in a merge group.

![image](https://user-images.githubusercontent.com/2347301/127396889-e552be5b-9b94-4d8e-b200-6b945c6e9742.png)
![image](https://user-images.githubusercontent.com/2347301/127396992-c066054c-7606-46b9-8226-e983834c6f1b.png)

Within the business logic:

* In `src/python/sortingview/gui/pluginInterface/SortingCuration.ts`:
  * Added `isClosed` optional property on `SortingCuration` type.
  * Added interfaces for close and reopen curation actions.
* In 'src/python/sortingview/gui/pluginInterface/workspaceReducer.ts`:
  * Added line to `sortingCurationReducer` so that, when a curation state is closed, any action other than reopening ought to result in a no-op.
  * Added state change toggle to handle the close- and reopen-curation actions.

In scripting:

* In `src/python/sortingview/workspace/workspace.py`:
  * Added matching `REOPEN` and `CLOSE` actions to the code that parses the feeds and reconstructs workspace state.
  * Included a check 

Incidental:

* Happened to notice a style tweak in `src/python/sortingview/user_permissions.py`. Sorry for the drive-by edit, but it seemed too small to file an issue about, and I didn't want to forget.

Testing:

* Ran UI in Vercel and confirmed state change logic (UI enabling/disabling) worked.
* Confirmed UI component state changed as expected to match curation completion state.
* Confirmed that loading a sorting curation through Python (as in procedure in issue #64) successfully reproduced UI state in both the closed and open cases
  * Incidentally verified that curation changes applied while curation was closed *will* be caught and errored out by this script.
  * ...deleted some messed-up sorting feeds and re-imported, and then verified that curation actions to a closed curation were no longer being sent to the back-end.

Potential issues:

* Curation closure is enforced in the reducers and reconstructor, and the UI does not allow curation of closed curation objects. However, this is achieved only through disabling the button, not making additional state checks in the callbacks in `CurationControl.tsx`. We *could* be more defense-in-depth here.