### PR TITLE
authorized access to workspace list

### DIFF
--- a/devel/example_auth_config.yaml
+++ b/devel/example_auth_config.yaml
@@ -1,0 +1,4 @@
+workspaceLists:
+  default:
+    -
+      userId: jmagland@flatironinstitute.org

--- a/src/labbox-react/MainWindow/WorkspaceList.tsx
+++ b/src/labbox-react/MainWindow/WorkspaceList.tsx
@@ -1,5 +1,6 @@
 import useChannel from 'kachery-react/useChannel'
 import useQueryTask from 'kachery-react/useQueryTask'
+import useGoogleSignInClient from 'labbox-react/googleSignIn/useGoogleSignInClient'
 import React, { FunctionComponent, useCallback } from 'react'
 import WorkspacesTable from './WorkspacesTable'
 
@@ -16,9 +17,19 @@ export type WorkspaceListWorkspace = {
 
 const WorkspaceList: FunctionComponent<Props> = ({onWorkspaceSelected, packageName}) => {
     const {channelName} = useChannel()
+    const client = useGoogleSignInClient()
 
     // This is the newer system for getting the workspace list
-    const {returnValue: workspaceList, task} = useQueryTask<WorkspaceListWorkspace[]>(channelName ? `sortingview.get_workspace_list.1` : undefined, {name: 'default'}, {fallbackToCache: true, channelName})
+    const {returnValue: workspaceList, task} = useQueryTask<WorkspaceListWorkspace[]>(
+        channelName ? `sortingview.get_workspace_list.1` : undefined,
+        {
+            name: 'default',
+            id_token: client ? client.idToken : undefined
+        }, {
+            fallbackToCache: true,
+            channelName
+        }
+    )
     
     const handleWorkspaceSelected = useCallback((w: WorkspaceListWorkspace) => {
         onWorkspaceSelected(w.workspaceUri)

--- a/src/labbox-react/googleSignIn/useSetupGoogleSignIn.ts
+++ b/src/labbox-react/googleSignIn/useSetupGoogleSignIn.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import GoogleSignInClient from './GoogleSignInClient'
 import {GoogleSignInData} from './GoogleSignInContext'
 import loadGoogleSignInClientOpts from './loadGoogleSignInClientOpts'
@@ -6,16 +6,23 @@ import loadGoogleSignInClientOpts from './loadGoogleSignInClientOpts'
 const useSetupGoogleSignIn = (): GoogleSignInData => {
     const opts = useMemo(() => (loadGoogleSignInClientOpts()), [])
     const [client, setClient] = useState<GoogleSignInClient | undefined>(undefined)
+    const [updateCode, setUpdateCode] = useState<number>(0)
+    const incrementUpdateCode = useCallback(() => {setUpdateCode(c => (c+1))}, [])
     useEffect(() => {
         if (!opts) return
         const c = new GoogleSignInClient(opts)
         c.initialize().then(() => {
+            c.onSignedInChanged(() => {
+                // update the state if sign in has changed (although the client will remain the same)
+                incrementUpdateCode()
+            })
             setClient(c)
         })
-    }, [opts])
-    return {
+    }, [opts, incrementUpdateCode])
+    return useMemo(() => ({
+        updateCode,
         client
-    }
+    }), [client, updateCode])
 }
 
 export default useSetupGoogleSignIn

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -12,6 +12,8 @@ setup(
         'kachery-client>=1.0.12',
         'pynwb',
         'pyyaml',
-        'spikeextractors>=0.9.6'
+        'spikeextractors>=0.9.6',
+        'google-auth',
+        'cachecontrol'
     ]
 )

--- a/src/python/sortingview/tasks/_verify_oauth2_token.py
+++ b/src/python/sortingview/tasks/_verify_oauth2_token.py
@@ -1,0 +1,12 @@
+from google.oauth2 import id_token
+import cachecontrol
+import google.auth.transport.requests
+import requests
+
+session = requests.session()
+cached_session = cachecontrol.CacheControl(session)
+request = google.auth.transport.requests.Request(session=cached_session)
+
+def _verify_oauth2_token(token: bytes):
+    id_info = id_token.verify_oauth2_token(token, request)
+    return id_info

--- a/src/python/sortingview/tasks/get_workspace_list.py
+++ b/src/python/sortingview/tasks/get_workspace_list.py
@@ -1,8 +1,39 @@
+import os
+from typing import Union
 import kachery_client as kc
+import yaml
 
 from ..workspace_list import get_workspace_list, set_workspace_list
+from ._verify_oauth2_token import _verify_oauth2_token
+
+auth_config_path = os.getenv('SORTINGVIEW_AUTH_CONFIG', None)
+if auth_config_path is not None:
+    print(f'Using auth config file: {auth_config_path}')
+    with open(auth_config_path, 'r') as f:
+        auth_config = yaml.safe_load(f)
+else:
+    print('Using default auth config. To override, set SORTINGVIEW_AUTH_CONFIG to path of a yaml file.')
+    auth_config = {}
+
+workspace_lists_auth_config = auth_config.get('workspaceLists', None)
 
 @kc.taskfunction('sortingview.get_workspace_list.1', type='query')
-def task_get_workspace_list(name: str):
+def task_get_workspace_list(name: str, id_token: Union[str, None]=None):
+    if id_token is not None:
+        id_info = _verify_oauth2_token(id_token.encode('utf-8'))
+        auth_user_id = id_info['email']
+    else:
+        auth_user_id = None
+    if workspace_lists_auth_config is not None:
+        if auth_user_id is None: raise Exception('Not authorized (not logged in)')
+        ok = False
+        for list_name, c in workspace_lists_auth_config.items():
+            if list_name == name:
+                for x in c:
+                    if x['userId'] == auth_user_id:
+                        ok = True
+    else:
+        ok = True
+    if not ok: raise Exception('Not authorized')
     workspace_list = get_workspace_list(name=name)
     return workspace_list


### PR DESCRIPTION
Fixes #84

@jsoules, this is not a perfect solution, but I think it will work for now and it won't be too disruptive to update it with something better down the road. Here's how it works for now:

If you run the backend you will see the following message

```
Using default auth config. To override, set SORTINGVIEW_AUTH_CONFIG to path of a yaml file.
```

If that env variable is not set, it will work the same as before (everyone can view the list of workspaces).

If the env variable is set, it should point to a yaml file. An example yaml file is included in devel/example_auth_config.yaml. This controls which google users have access to which workspace lists. Right now only the "default"  workspace list is used.