### PR TITLE
In RecordingsTable, lay out Sortings as a list on each Recording.

### DIFF
--- a/src/python/sortingview/gui/extensions/workspaceview/WorkspaceView/RecordingsTable.tsx
+++ b/src/python/sortingview/gui/extensions/workspaceview/WorkspaceView/RecordingsTable.tsx
@@ -19,24 +19,26 @@ const SortingElement: FunctionComponent<{sorting: Sorting, sortingInfo?: Sorting
         onClickSorting(sorting)
     }, [onClickSorting, sorting])
     return (
-        <p>
+        <li>
             <Hyperlink onClick={handleClick} key={sorting.sortingId}>
                 {sorting.sortingLabel} ({sortingInfo ? `${sortingInfo.unit_ids.length} units` : ''})
             </Hyperlink>
-        </p>
+        </li>
     )
 }
 
 const SortingsElement: FunctionComponent<{sortings: Sorting[], onClickSorting: (sorting: Sorting) => void}> = ({sortings, onClickSorting}) => {
     const sortingInfos = useSortingInfos(sortings)
     return (
-        <span>
-            {
-                sortings.map(s => (
-                    <SortingElement onClickSorting={onClickSorting} sorting={s} sortingInfo={sortingInfos[s.sortingId] || undefined} />
-                ))
-            }
-        </span>
+        <div style={{left: "-25px", position: "relative"}}>
+            <ul>
+                {
+                    sortings.map(s => (
+                        <SortingElement onClickSorting={onClickSorting} sorting={s} sortingInfo={sortingInfos[s.sortingId] || undefined} />
+                    ))
+                }
+            </ul>
+        </div>
     )
 }
 

--- a/src/python/sortingview/gui/extensions/workspaceview/WorkspaceView/RecordingsTable.tsx
+++ b/src/python/sortingview/gui/extensions/workspaceview/WorkspaceView/RecordingsTable.tsx
@@ -18,7 +18,13 @@ const SortingElement: FunctionComponent<{sorting: Sorting, sortingInfo?: Sorting
     const handleClick = useCallback(() => {
         onClickSorting(sorting)
     }, [onClickSorting, sorting])
-    return <Hyperlink onClick={handleClick} key={sorting.sortingId}>{sorting.sortingLabel} ({sortingInfo ? `${sortingInfo.unit_ids.length} units` : ''})</Hyperlink>
+    return (
+        <p>
+            <Hyperlink onClick={handleClick} key={sorting.sortingId}>
+                {sorting.sortingLabel} ({sortingInfo ? `${sortingInfo.unit_ids.length} units` : ''})
+            </Hyperlink>
+        </p>
+    )
 }
 
 const SortingsElement: FunctionComponent<{sortings: Sorting[], onClickSorting: (sorting: Sorting) => void}> = ({sortings, onClickSorting}) => {


### PR DESCRIPTION
Fixes #59.

This version of the code creates an unordered list in each recording, and includes each sorting as a list item:

![image](https://user-images.githubusercontent.com/2347301/127669250-9a19a634-9142-4a9a-80e4-fb5aeca5b3ac.png)

I think this is a nice compromise between clarity and a reasonably nice vertical spacing (I had previously had each one in its own P tag, but that generates too much whitespace). However, in a context where there may be many sortings per recording (e.g. SpikeForest data) this could potentially require some scrolling. An alternative (my originally plan, actually) would be to do a comma-separated list, but after seeing the vertical list in action I actually like it better. Happy to go with a different option, either now, or later on if it proves unwieldy for bigger lists.

Note there's a bit of inline styling at the level of the sorting lists, just to nudge them over to the left a bit--they were laying out weirdly to the right. This could certainly be done with a class if we want to be more robust about it.