### PR TITLE
For recordings with frame > (2 ** 31 - 1), data type of two variables in in prepare_spikesortingview_data need to change from np.int32 to np.int64.

### DIFF
--- a/sortingview/SpikeSortingView/prepare_spikesortingview_data.py
+++ b/sortingview/SpikeSortingView/prepare_spikesortingview_data.py
@@ -33,6 +33,7 @@ def prepare_spikesortingview_data(
         int_type = np.int64
     else:
         int_type = np.int32
+    print(f"int_type: {int_type}")
         
 
     with kcl.TemporaryDirectory() as tmpdir:

--- a/sortingview/SpikeSortingView/prepare_spikesortingview_data.py
+++ b/sortingview/SpikeSortingView/prepare_spikesortingview_data.py
@@ -19,17 +19,15 @@ def prepare_spikesortingview_data(
     channel_neighborhood_size: int,
     bandpass_filter: bool = False,
 ) -> str:
-
-
     # NOTE(DS): for data longer than 25hours with fs = 20000; num_frame is too large for int32
     if recording.get_num_frames() > (2 ** 31 - 1):
         int_type = np.int64
     else:
         int_type = np.int32
-        #int_type = np.int64 #NOTE(DS): to test in short recording
+        # int_type = np.int64 #NOTE(DS): to test in short recording
 
     print(f"int_type: {int_type}")
-    
+
     if bandpass_filter:
         recording = spre.bandpass_filter(recording)
     unit_ids = np.array(sorting.get_unit_ids()).astype(np.int32)
@@ -38,9 +36,6 @@ def prepare_spikesortingview_data(
     num_frames = recording.get_num_frames()
     num_frames_per_segment = math.ceil(segment_duration_sec * sampling_frequency)
     num_segments = math.ceil(num_frames / num_frames_per_segment)
-
-
-
 
     with kcl.TemporaryDirectory() as tmpdir:
         output_file_name = tmpdir + "/spikesortingview.h5"
@@ -109,7 +104,7 @@ def prepare_spikesortingview_data(
                 start_frame_with_padding = max(start_frame - snippet_len[0], 0)
                 end_frame_with_padding = min(end_frame + snippet_len[1], num_frames)
                 traces_with_padding = recording.get_traces(start_frame=start_frame_with_padding, end_frame=end_frame_with_padding)
-                traces_sample = traces_with_padding[start_frame - start_frame_with_padding : start_frame - start_frame_with_padding + int(sampling_frequency * 1), :]
+                traces_sample = traces_with_padding[start_frame - start_frame_with_padding: start_frame - start_frame_with_padding + int(sampling_frequency * 1), :]
                 f.create_dataset(f"segment/{iseg}/traces_sample", data=traces_sample)
                 all_subsampled_spike_trains = []
                 for unit_id in unit_ids:
@@ -142,7 +137,7 @@ def prepare_spikesortingview_data(
                     channel_neighborhood = unit_channel_neighborhoods[str(unit_id)]
                     channel_neighborhood_indices = [channel_ids.tolist().index(ch_id) for ch_id in channel_neighborhood]
                     num = len(all_subsampled_spike_trains[ii])
-                    spike_snippets = spike_snippets_concat[index : index + num, :, channel_neighborhood_indices]
+                    spike_snippets = spike_snippets_concat[index: index + num, :, channel_neighborhood_indices]
                     index = index + num
                     f.create_dataset(f"segment/{iseg}/unit/{unit_id}/subsampled_spike_snippets", data=spike_snippets)
         uri = kcl.store_file_local(output_file_name)
@@ -170,7 +165,7 @@ def subsample(x: np.ndarray, num: int):
     if num >= len(x):
         return x
     stride = math.floor(len(x) / num)
-    return x[0 : stride * num : stride]
+    return x[0: stride * num: stride]
 
 
 def extract_spike_snippets(*, traces: np.ndarray, times: np.ndarray, snippet_len: Tuple[int, int]):


### PR DESCRIPTION
For recordings with frame > 2**31 - 1 (about 29.8h recording with Fs=20000), `num_frames` should be in `np.int64`

and `spike_train` should have elements in `np.int64`.

I changed these variables to have data type of `np.int64` only when `recording.get_num_frames() > (2 ** 31 - 1)`.


I tested this version for two 2.64 days recordings one sorted with scheme3 with `block_size = a day`, and the other one with scheme2.  